### PR TITLE
Add support for message fields: "allowedMentions" and "flags"

### DIFF
--- a/src/DiscordMessage.php
+++ b/src/DiscordMessage.php
@@ -114,6 +114,12 @@ class DiscordMessage implements Arrayable
             'tts' => $this->tts,
             'allowed_mentions' => $this->allowedMentions,
             'flags' => $this->flags,
-        ], fn ($value) => !is_null($value));
+        ], function ($value) {
+            if (is_array($value) && count($value) === 0) {
+                return false;
+            }
+
+            return !is_null($value);
+        });
     }
 }

--- a/src/DiscordMessage.php
+++ b/src/DiscordMessage.php
@@ -1,5 +1,5 @@
 <?php
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace SnoerenDevelopment\DiscordWebhook;
 
@@ -20,12 +20,8 @@ class DiscordMessage implements Arrayable
     /** Indicates that this is a Text-to-speech message. */
     protected ?bool $tts = null;
 
-    /**
-     * Controls what mentions are allowed in the message.
-     * 
-     * Allowed values: "everyone", "roles", "users"
-     */
-    protected array $allowedMentions = [];
+    /** Controls what mentions are allowed in the message. */
+    protected DiscordMessageAllowedMentions|null $allowedMentions;
 
     /**
      * Message flags.
@@ -76,12 +72,8 @@ class DiscordMessage implements Arrayable
         return $this;
     }
 
-    /**
-     * Set the allowed mentions.
-     *
-     * @param  array<string> $allowedMentions The allowed mentions. Allowed values: "everyone", "roles", "users"
-     */
-    public function allowedMentions(array $allowedMentions): self
+    /** Set the allowed mentions. */
+    public function allowedMentions(DiscordMessageAllowedMentions $allowedMentions): self
     {
         $this->allowedMentions = $allowedMentions;
         return $this;
@@ -112,7 +104,7 @@ class DiscordMessage implements Arrayable
             'username' => $this->username,
             'avatar_url' => $this->avatarUrl,
             'tts' => $this->tts,
-            'allowed_mentions' => $this->allowedMentions,
+            'allowed_mentions' => $this->allowedMentions?->toArray(),
             'flags' => $this->flags,
         ], function ($value) {
             if (is_array($value) && count($value) === 0) {

--- a/src/DiscordMessage.php
+++ b/src/DiscordMessage.php
@@ -27,6 +27,13 @@ class DiscordMessage implements Arrayable
      */
     protected array $allowedMentions = [];
 
+    /**
+     * Message flags.
+     * 
+     * @see \SnoerenDevelopment\DiscordWebhook\DiscordMessageFlags
+     */
+    protected int|null $flags = null;
+
     /** Create a new Discord message instance. */
     public static function create(): self
     {
@@ -81,6 +88,19 @@ class DiscordMessage implements Arrayable
     }
 
     /**
+     * Set the message flags.
+     * 
+     * @see \SnoerenDevelopment\DiscordWebhook\DiscordMessageFlags
+     * @param  int $flags The message flags.
+     * @return \SnoerenDevelopment\DiscordWebhook\DiscordMessage
+     */
+    public function flags(int $flags): self
+    {
+        $this->flags = $flags;
+        return $this;
+    }
+
+    /**
      * Get the instance as an array.
      *
      * @return array<string, mixed>
@@ -93,6 +113,7 @@ class DiscordMessage implements Arrayable
             'avatar_url' => $this->avatarUrl,
             'tts' => $this->tts,
             'allowed_mentions' => $this->allowedMentions,
+            'flags' => $this->flags,
         ], fn ($value) => !is_null($value));
     }
 }

--- a/src/DiscordMessage.php
+++ b/src/DiscordMessage.php
@@ -21,7 +21,7 @@ class DiscordMessage implements Arrayable
     protected ?bool $tts = null;
 
     /** Controls what mentions are allowed in the message. */
-    protected DiscordMessageAllowedMentions|null $allowedMentions;
+    protected DiscordMessageAllowedMentions|null $allowedMentions = null;
 
     /**
      * Message flags.

--- a/src/DiscordMessage.php
+++ b/src/DiscordMessage.php
@@ -20,6 +20,13 @@ class DiscordMessage implements Arrayable
     /** Indicates that this is a Text-to-speech message. */
     protected ?bool $tts = null;
 
+    /**
+     * Controls what mentions are allowed in the message.
+     * 
+     * Allowed values: "everyone", "roles", "users"
+     */
+    protected array $allowedMentions = [];
+
     /** Create a new Discord message instance. */
     public static function create(): self
     {
@@ -63,6 +70,17 @@ class DiscordMessage implements Arrayable
     }
 
     /**
+     * Set the allowed mentions.
+     *
+     * @param  array<string> $allowedMentions The allowed mentions. Allowed values: "everyone", "roles", "users"
+     */
+    public function allowedMentions(array $allowedMentions): self
+    {
+        $this->allowedMentions = $allowedMentions;
+        return $this;
+    }
+
+    /**
      * Get the instance as an array.
      *
      * @return array<string, mixed>
@@ -74,6 +92,7 @@ class DiscordMessage implements Arrayable
             'username' => $this->username,
             'avatar_url' => $this->avatarUrl,
             'tts' => $this->tts,
+            'allowed_mentions' => $this->allowedMentions,
         ], fn ($value) => !is_null($value));
     }
 }

--- a/src/DiscordMessageAllowedMentions.php
+++ b/src/DiscordMessageAllowedMentions.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace SnoerenDevelopment\DiscordWebhook;
+
+use Illuminate\Contracts\Support\Arrayable;
+
+/** @implements Arrayable<string, mixed> */
+class DiscordMessageAllowedMentions implements Arrayable
+{
+
+    /** List of users that can be pinged or wheter or not to allow users pings. */
+    protected array|bool|null $allowUsers = null;
+
+    /** List of roles that can be pinged or whether or not to allow roles pings. */
+    protected array|bool|null $allowRoles = null;
+
+    /** Indicates that "everyone" mentions are allowed. */
+    protected bool|null $allowEveryone = null;
+
+    /** Create a new Discord allowed mentions instance. */
+    public static function create(): self
+    {
+        return new self;
+    }
+
+    /** Set whether or not to allow "everyone" pings. */
+    public function everyone(bool $allowed): self
+    {
+        $this->allowEveryone = $allowed;
+        return $this;
+    }
+
+    /** Set whether or not to allow user pings. */
+    public function allUsers(bool $allowed): self
+    {
+        $this->allowUsers = $allowed;
+        return $this;
+    }
+
+    /** 
+     * Set what users can be pinged.
+     * 
+     * @param array<string> $userIds
+     */
+    public function allowUsers(array $userIds): self
+    {
+        $this->allowUsers = $userIds;
+        return $this;
+    }
+
+    /** Set whether or not to allow role pings. */
+    public function allRoles(bool $allowed): self
+    {
+        $this->allowRoles = $allowed;
+        return $this;
+    }
+
+    /** 
+     * Set what roles can be pinged.
+     * 
+     * @param array<string> $roleIds
+     */
+    public function allowRoles(array $roleIds): self
+    {
+        $this->allowRoles = $roleIds;
+        return $this;
+    }
+
+    /** Disable all mentions. */
+    public function disableAll(): self
+    {
+        $this->allowUsers = false;
+        $this->allowRoles = false;
+        $this->allowEveryone = false;
+        return $this;
+    }
+
+    /**
+     * Get the instance as an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $parseArray = null;
+
+        if ($this->allowUsers === false || $this->allowRoles === false || $this->allowEveryone === false) {
+            $parseArray = []; // Empty array denotes that no mentions are allowed
+        }
+
+        if ($this->allowUsers === true) {
+            $parseArray ??= [];
+            $parseArray[] = "users";
+        }
+
+        if ($this->allowRoles === true) {
+            $parseArray ??= [];
+            $parseArray[] = "roles";
+        }
+
+        if ($this->allowEveryone === true) {
+            $parseArray ??= [];
+            $parseArray[] = "everyone";
+        }
+
+        $output = [
+            "parse" => $parseArray,
+        ];
+
+        if (is_array($this->allowUsers)) {
+            $output["users"] = array_values($this->allowUsers);
+        }
+
+        if (is_array($this->allowRoles)) {
+            $output["roles"] = array_values($this->allowRoles);
+        }
+
+        return $output;
+    }
+}

--- a/src/DiscordMessageFlags.php
+++ b/src/DiscordMessageFlags.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types = 1);
+
+namespace SnoerenDevelopment\DiscordWebhook;
+
+final abstract class DiscordMessageFlags
+{
+    // Only these bitflags can be set when sending a message through a webhook.
+    // @see https://discord.com/developers/docs/resources/webhook#execute-webhook-jsonform-params
+
+    /**
+     * Indicates that the message should not include any embeds when serializing this message.
+     * 
+     * @const int
+     */
+    public const SUPPRESS_EMBEDS = 1 << 2;
+
+    /**
+     * Indicates that the message should not trigger push and desktop notifications.
+     * 
+     * @const int
+     */
+    public const SUPPRESS_NOTIFICATIONS = 1 << 12;
+}

--- a/src/DiscordMessageFlags.php
+++ b/src/DiscordMessageFlags.php
@@ -3,7 +3,7 @@ declare(strict_types = 1);
 
 namespace SnoerenDevelopment\DiscordWebhook;
 
-final abstract class DiscordMessageFlags
+abstract class DiscordMessageFlags
 {
     // Only these bitflags can be set when sending a message through a webhook.
     // @see https://discord.com/developers/docs/resources/webhook#execute-webhook-jsonform-params


### PR DESCRIPTION
This PR adds support to new message fields that are included in Discord docs:
- `allowedMentions` - allows to set up what mentions can be used in message that is sent by webhook - it's useful when someone would want to pass through user generated text to webhook message and doesn't want to allow mentions in it.
- `flags` - there are only two flags supported, but are useful as well.

 